### PR TITLE
resolution of Issue #29

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ class Speedometer extends Component {
       labelWrapperStyle,
       labelStyle,
       labelNoteStyle,
+      useNativeDriver
     } = this.props;
     const degree = 180;
     const perLevelDegree = calculateDegreeFromLabels(degree, labels);
@@ -57,6 +58,7 @@ class Speedometer extends Component {
         toValue: limitValue(value, minValue, maxValue, allowedDecimals),
         duration: easeDuration,
         easing: Easing.linear,
+        useNativeDriver: useNativeDriver
       },
     ).start();
 
@@ -187,6 +189,7 @@ Speedometer.defaultProps = {
   labelWrapperStyle: {},
   labelStyle: {},
   labelNoteStyle: {},
+  useNativeDriver: true
 };
 
 Speedometer.propTypes = {
@@ -208,6 +211,7 @@ Speedometer.propTypes = {
   labelWrapperStyle: PropTypes.object,
   labelStyle: PropTypes.object,
   labelNoteStyle: PropTypes.object,
+  useNativeDriver: PropTypes.bool
 };
 
 export default Speedometer;

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class Speedometer extends Component {
       labelWrapperStyle,
       labelStyle,
       labelNoteStyle,
-      useNativeDriver
+      useNativeDriver,
     } = this.props;
     const degree = 180;
     const perLevelDegree = calculateDegreeFromLabels(degree, labels);
@@ -58,7 +58,7 @@ class Speedometer extends Component {
         toValue: limitValue(value, minValue, maxValue, allowedDecimals),
         duration: easeDuration,
         easing: Easing.linear,
-        useNativeDriver: useNativeDriver
+        useNativeDriver,
       },
     ).start();
 
@@ -189,7 +189,7 @@ Speedometer.defaultProps = {
   labelWrapperStyle: {},
   labelStyle: {},
   labelNoteStyle: {},
-  useNativeDriver: true
+  useNativeDriver: true,
 };
 
 Speedometer.propTypes = {
@@ -211,7 +211,7 @@ Speedometer.propTypes = {
   labelWrapperStyle: PropTypes.object,
   labelStyle: PropTypes.object,
   labelNoteStyle: PropTypes.object,
-  useNativeDriver: PropTypes.bool
+  useNativeDriver: PropTypes.bool,
 };
 
 export default Speedometer;


### PR DESCRIPTION
Added the ability to have a dynamic value for the useNativeDriver on the Animation.timing of the speedometer image. This will remove the warning from a react native or expo project, and still allow for flexibility of users who may wish to disable this for specific devices. 

defaultProp of useNativeDriver prop has been set to true.

PropType of useNativeDriver prop has been set to boolean.

this pull request aims to solve the issue in the creator's repository.

pritishvaidya/react-native-speedometer#29